### PR TITLE
Persistence of default configuration values

### DIFF
--- a/src/ConfigurationCardConfigReader/ConfigurationCardProviderProvider.php
+++ b/src/ConfigurationCardConfigReader/ConfigurationCardProviderProvider.php
@@ -16,6 +16,19 @@ final class ConfigurationCardProviderProvider implements ConfigurationCardProvid
     ) {
     }
 
+    public function getBundleClasses(): array
+    {
+        $bundleClasses = [];
+        foreach ($this->getConfigurationCardProviders() as $configurationCardProvider) {
+            $bundleClasses = array_merge($bundleClasses, $configurationCardProvider->getBundleClasses());
+        }
+
+        return array_values(array_unique($bundleClasses));
+    }
+
+    /**
+     * @return iterable<ConfigurationCardProvider>
+     */
     public function getConfigurationCardProviders(): iterable
     {
         $configurationCardProviders = [...$this->configurationCardProviders];

--- a/src/ConfigurationCardConfigReader/ConfigurationCardProviderProviderInterface.php
+++ b/src/ConfigurationCardConfigReader/ConfigurationCardProviderProviderInterface.php
@@ -5,9 +5,15 @@ declare(strict_types=1);
 namespace ITB\ShopwareCodeBasedPluginConfiguration\ConfigurationCardConfigReader;
 
 use ITB\ShopwareCodeBasedPluginConfiguration\ConfigurationCardProvider;
+use Shopware\Core\Framework\Bundle;
 
 interface ConfigurationCardProviderProviderInterface
 {
+    /**
+     * @return class-string<Bundle>[]
+     */
+    public function getBundleClasses(): array;
+
     /**
      * @return iterable<ConfigurationCardProvider>
      */

--- a/src/ConfigurationCardConfigSaver.php
+++ b/src/ConfigurationCardConfigSaver.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ShopwareCodeBasedPluginConfiguration;
+
+use ITB\ShopwareCodeBasedPluginConfiguration\ConfigurationCardConfigReader\ConfigurationCardProviderProviderInterface;
+use Shopware\Core\Framework\Bundle;
+use Shopware\Core\Framework\Plugin\Event\PluginPostActivateEvent;
+use Shopware\Core\Framework\Plugin\Event\PluginPostUpdateEvent;
+use Shopware\Core\Framework\Plugin\KernelPluginCollection;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class ConfigurationCardConfigSaver implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly ConfigurationCardProviderProviderInterface $configurationCardProviderProvider,
+        private readonly KernelPluginCollection $kernelPluginCollection,
+        private readonly SystemConfigService $systemConfigService
+    ) {
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: int}[]>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            PluginPostActivateEvent::class => [['saveConfiguration', 100]],
+            PluginPostUpdateEvent::class => [['saveConfiguration', 100]],
+        ];
+    }
+
+    public function saveConfiguration(PluginPostActivateEvent|PluginPostUpdateEvent $event): void
+    {
+        $bundleClassesThatUsesConfigurationCardProviders = $this->configurationCardProviderProvider->getBundleClasses();
+
+        $pluginBaseClass = $event->getPlugin()
+            ->getBaseClass();
+        if (in_array($pluginBaseClass, $bundleClassesThatUsesConfigurationCardProviders) === false) {
+            return;
+        }
+
+        $plugin = $this->kernelPluginCollection->get($pluginBaseClass);
+        if (! $plugin instanceof Bundle) {
+            return;
+        }
+
+        $this->systemConfigService->savePluginConfiguration($plugin);
+    }
+}

--- a/src/DependencyInjection/ConfigurationCardConfigSaverPass.php
+++ b/src/DependencyInjection/ConfigurationCardConfigSaverPass.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ShopwareCodeBasedPluginConfiguration\DependencyInjection;
+
+use ITB\ShopwareCodeBasedPluginConfiguration\ConfigurationCardConfigReader\ConfigurationCardProviderProviderInterface;
+use ITB\ShopwareCodeBasedPluginConfiguration\ConfigurationCardConfigSaver;
+use Shopware\Core\Framework\Plugin\KernelPluginCollection;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class ConfigurationCardConfigSaverPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $configurationCardSaverDefinition = new Definition(ConfigurationCardConfigSaver::class);
+        $configurationCardSaverDefinition->setArgument(
+            '$configurationCardProviderProvider',
+            new Reference(ConfigurationCardProviderProviderInterface::class)
+        );
+        $configurationCardSaverDefinition->setArgument('$kernelPluginCollection', new Reference(KernelPluginCollection::class));
+        $configurationCardSaverDefinition->setArgument('$systemConfigService', new Reference(SystemConfigService::class));
+        $configurationCardSaverDefinition->addTag('kernel.event_subscriber');
+
+        $container->addDefinitions([
+            ConfigurationCardConfigSaver::class => $configurationCardSaverDefinition,
+        ]);
+    }
+}

--- a/tests/Unit/ConfigurationCardConfigReader/ConfigurationCardProviderProviderTest.php
+++ b/tests/Unit/ConfigurationCardConfigReader/ConfigurationCardProviderProviderTest.php
@@ -20,6 +20,60 @@ final class ConfigurationCardProviderProviderTest extends TestCase
         yield [[$configurationCardProvider]];
     }
 
+    public static function getBundleClassesProvider(): \Generator
+    {
+        $configurationCardProviderProvider = new ConfigurationCardProviderProvider([]);
+        yield 'without configuration card providers' => [$configurationCardProviderProvider, []];
+
+        $configurationCardProvider1 = self::createStub(ConfigurationCardProvider::class);
+        $configurationCardProvider1->method('getBundleClasses')
+            ->willReturn(['BundleClass1', 'BundleClass2']);
+        $configurationCardProvider2 = self::createStub(ConfigurationCardProvider::class);
+        $configurationCardProvider2->method('getBundleClasses')
+            ->willReturn(['BundleClass3', 'BundleClass4']);
+
+        $configurationCardProviderProvider = new ConfigurationCardProviderProvider([
+            $configurationCardProvider1,
+            $configurationCardProvider2,
+        ]);
+        yield 'with two configuration card providers with different bundle classes' => [
+            $configurationCardProviderProvider,
+            ['BundleClass1', 'BundleClass2', 'BundleClass3', 'BundleClass4'],
+        ];
+
+        $configurationCardProvider3 = self::createStub(ConfigurationCardProvider::class);
+        $configurationCardProvider3->method('getBundleClasses')
+            ->willReturn(['BundleClass1', 'BundleClass2']);
+        $configurationCardProvider4 = self::createStub(ConfigurationCardProvider::class);
+        $configurationCardProvider4->method('getBundleClasses')
+            ->willReturn(['BundleClass2', 'BundleClass3']);
+
+        $configurationCardProviderProvider = new ConfigurationCardProviderProvider([
+            $configurationCardProvider3,
+            $configurationCardProvider4,
+        ]);
+        yield 'with two configuration card providers with partly overlapping bundle classes' => [
+            $configurationCardProviderProvider,
+            ['BundleClass1', 'BundleClass2', 'BundleClass3'],
+        ];
+
+        $configurationCardProvider5 = self::createStub(ConfigurationCardProvider::class);
+        $configurationCardProvider5->method('getBundleClasses')
+            ->willReturn(['BundleClass1', 'BundleClass2']);
+        $configurationCardProvider6 = self::createStub(ConfigurationCardProvider::class);
+        $configurationCardProvider6->method('getBundleClasses')
+            ->willReturn(['BundleClass1', 'BundleClass2']);
+
+        $configurationCardProviderProvider = new ConfigurationCardProviderProvider([
+            $configurationCardProvider5,
+            $configurationCardProvider6,
+        ]);
+        yield 'with two configuration card providers with overlapping bundle classes' => [
+            $configurationCardProviderProvider,
+            ['BundleClass1', 'BundleClass2'],
+        ];
+    }
+
     public static function getConfigurationCardProvidersProvider(): \Generator
     {
         $configurationCardProviderProvider = new ConfigurationCardProviderProvider([]);
@@ -50,6 +104,18 @@ final class ConfigurationCardProviderProviderTest extends TestCase
     {
         $configurationCardProviderProvider = new ConfigurationCardProviderProvider($configurationCardProviders);
         $this->assertInstanceOf(ConfigurationCardProviderProvider::class, $configurationCardProviderProvider);
+    }
+
+    /**
+     * @param string[] $expectedBundleClasses
+     */
+    #[DataProvider('getBundleClassesProvider')]
+    public function testGetBundleClasses(
+        ConfigurationCardProviderProvider $configurationCardProviderProvider,
+        array $expectedBundleClasses
+    ): void {
+        $bundleClasses = $configurationCardProviderProvider->getBundleClasses();
+        $this->assertSame($expectedBundleClasses, $bundleClasses);
     }
 
     /**

--- a/tests/Unit/ConfigurationCardConfigSaverTest.php
+++ b/tests/Unit/ConfigurationCardConfigSaverTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ShopwareCodeBasedPluginConfiguration\Test\Unit;
+
+use ITB\ShopwareCodeBasedPluginConfiguration\ConfigurationCardConfigReader\ConfigurationCardProviderProvider;
+use ITB\ShopwareCodeBasedPluginConfiguration\ConfigurationCardConfigReader\ConfigurationCardProviderProviderInterface;
+use ITB\ShopwareCodeBasedPluginConfiguration\ConfigurationCardConfigSaver;
+use ITB\ShopwareCodeBasedPluginConfiguration\ConfigurationCardProvider;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Bundle;
+use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\Plugin\Event\PluginPostActivateEvent;
+use Shopware\Core\Framework\Plugin\Event\PluginPostUpdateEvent;
+use Shopware\Core\Framework\Plugin\KernelPluginCollection;
+use Shopware\Core\Framework\Plugin\PluginEntity;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+
+final class ConfigurationCardConfigSaverTest extends TestCase
+{
+    public static function saveConfigurationSkippedProvider(): \Generator
+    {
+        $plugin = self::createStub(Plugin::class);
+        $pluginEntity = self::createStub(PluginEntity::class);
+        $pluginEntity->method('getBaseClass')
+            ->willReturn($plugin::class);
+
+        $configurationCardProvider = self::createStub(ConfigurationCardProvider::class);
+        $configurationCardProvider->method('getBundleClasses')
+            ->willReturn([]);
+        $configurationCardProviderProvider = new ConfigurationCardProviderProvider([$configurationCardProvider]);
+
+        $kernelPluginCollection = self::createStub(KernelPluginCollection::class);
+
+        $event = self::createStub(PluginPostActivateEvent::class);
+        $event->method('getPlugin')
+            ->willReturn($pluginEntity);
+
+        yield 'bundle class not defined in configuration card providers' => [
+            $configurationCardProviderProvider,
+            $kernelPluginCollection,
+            $event,
+            $plugin,
+        ];
+
+        $configurationCardProvider = self::createStub(ConfigurationCardProvider::class);
+        $configurationCardProvider->method('getBundleClasses')
+            ->willReturn([$plugin::class]);
+        $configurationCardProviderProvider = new ConfigurationCardProviderProvider([$configurationCardProvider]);
+
+        $kernelPluginCollection = self::createStub(KernelPluginCollection::class);
+        $kernelPluginCollection->method('get')
+            ->willReturn(null);
+
+        $event = self::createStub(PluginPostActivateEvent::class);
+        $event->method('getPlugin')
+            ->willReturn($pluginEntity);
+
+        yield 'plugin instance not in kernel plugin collection' => [
+            $configurationCardProviderProvider,
+            $kernelPluginCollection,
+            $event,
+            $plugin,
+        ];
+    }
+
+    public static function saveConfigurationSuccessfulProvider(): \Generator
+    {
+        $plugin = self::createStub(Plugin::class);
+        $pluginEntity = self::createStub(PluginEntity::class);
+        $pluginEntity->method('getBaseClass')
+            ->willReturn($plugin::class);
+
+        $configurationCardProvider = self::createStub(ConfigurationCardProvider::class);
+        $configurationCardProvider->method('getBundleClasses')
+            ->willReturn([$plugin::class]);
+        $configurationCardProviderProvider = new ConfigurationCardProviderProvider([$configurationCardProvider]);
+
+        $kernelPluginCollection = self::createStub(KernelPluginCollection::class);
+        $kernelPluginCollection->method('get')
+            ->willReturnMap([[$plugin::class, $plugin]]);
+
+        $event = self::createStub(PluginPostActivateEvent::class);
+        $event->method('getPlugin')
+            ->willReturn($pluginEntity);
+
+        yield [$configurationCardProviderProvider, $kernelPluginCollection, $event, $plugin];
+    }
+
+    public function testGetSubscribedEvents(): void
+    {
+        $expectedSubscribedEvents = [
+            PluginPostActivateEvent::class => [['saveConfiguration', 100]],
+            PluginPostUpdateEvent::class => [['saveConfiguration', 100]],
+        ];
+
+        $this->assertSame($expectedSubscribedEvents, ConfigurationCardConfigSaver::getSubscribedEvents());
+    }
+
+    #[DataProvider('saveConfigurationSkippedProvider')]
+    public function testSaveConfigurationSkipped(
+        ConfigurationCardProviderProviderInterface $configurationCardProviderProvider,
+        KernelPluginCollection $kernelPluginCollection,
+        PluginPostActivateEvent|PluginPostUpdateEvent $event,
+    ): void {
+        $systemConfigService = $this->createMock(SystemConfigService::class);
+        $systemConfigService->expects($this->never())
+            ->method('savePluginConfiguration');
+
+        $configurationCardConfigSaver = new ConfigurationCardConfigSaver(
+            $configurationCardProviderProvider,
+            $kernelPluginCollection,
+            $systemConfigService
+        );
+
+        $configurationCardConfigSaver->saveConfiguration($event);
+    }
+
+    #[DataProvider('saveConfigurationSuccessfulProvider')]
+    public function testSaveConfigurationSuccessful(
+        ConfigurationCardProviderProviderInterface $configurationCardProviderProvider,
+        KernelPluginCollection $kernelPluginCollection,
+        PluginPostActivateEvent|PluginPostUpdateEvent $event,
+        Bundle $expectedBundle
+    ): void {
+        $systemConfigService = $this->createMock(SystemConfigService::class);
+        $systemConfigService->method('savePluginConfiguration')
+            ->willReturnCallback(function (Bundle $bundle) use ($expectedBundle): void {
+                $this->assertEquals($expectedBundle, $bundle);
+            });
+
+        $configurationCardConfigSaver = new ConfigurationCardConfigSaver(
+            $configurationCardProviderProvider,
+            $kernelPluginCollection,
+            $systemConfigService
+        );
+
+        $configurationCardConfigSaver->saveConfiguration($event);
+    }
+}

--- a/tests/Unit/DependencyInjection/ConfigurationCardConfigSaverPassTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationCardConfigSaverPassTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ShopwareCodeBasedPluginConfiguration\Test\Unit\DependencyInjection;
+
+use ITB\ShopwareCodeBasedPluginConfiguration\ConfigurationCardConfigReader\ConfigurationCardProviderProviderInterface;
+use ITB\ShopwareCodeBasedPluginConfiguration\ConfigurationCardConfigSaver;
+use ITB\ShopwareCodeBasedPluginConfiguration\ConfigurationCardProvider;
+use ITB\ShopwareCodeBasedPluginConfiguration\DependencyInjection\ConfigurationCardConfigSaverPass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Plugin\KernelPluginCollection;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class ConfigurationCardConfigSaverPassTest extends TestCase
+{
+    public static function processProvider(): \Generator
+    {
+        $configurationCardConfigSaverPass = new ConfigurationCardConfigSaverPass();
+        $container = new ContainerBuilder();
+
+        $configurationCardProviderStub = self::createStub(ConfigurationCardProvider::class);
+        $configurationCardProviderStubDefinition = new Definition($configurationCardProviderStub::class);
+        $container->setDefinition($configurationCardProviderStub::class, $configurationCardProviderStubDefinition);
+
+        $kernelPluginCollectionDefinition = new Definition(KernelPluginCollection::class);
+        $container->addDefinitions([
+            KernelPluginCollection::class => $kernelPluginCollectionDefinition,
+        ]);
+
+        $systemConfigServiceDefinition = new Definition(SystemConfigService::class);
+        $container->addDefinitions([
+            SystemConfigService::class => $systemConfigServiceDefinition,
+        ]);
+
+        yield 'with one card configuration provider' => [$configurationCardConfigSaverPass, $container];
+    }
+
+    #[DataProvider('processProvider')]
+    public function testProcess(ConfigurationCardConfigSaverPass $configurationCardConfigSaverPass, ContainerBuilder $container): void
+    {
+        $configurationCardConfigSaverPass->process($container);
+        $this->assertTrue($container->hasDefinition(ConfigurationCardConfigSaver::class));
+        $configurationCardConfigSaverDefinition = $container->getDefinition(ConfigurationCardConfigSaver::class);
+
+        $this->assertArrayHasKey('$configurationCardProviderProvider', $configurationCardConfigSaverDefinition->getArguments());
+        $configurationCardProviderProviderArgument = $configurationCardConfigSaverDefinition->getArgument(
+            '$configurationCardProviderProvider'
+        );
+        $this->assertInstanceOf(Reference::class, $configurationCardProviderProviderArgument);
+        $this->assertSame(ConfigurationCardProviderProviderInterface::class, (string) $configurationCardProviderProviderArgument);
+
+        $this->assertArrayHasKey('$kernelPluginCollection', $configurationCardConfigSaverDefinition->getArguments());
+        $kernelPluginCollectionArgument = $configurationCardConfigSaverDefinition->getArgument('$kernelPluginCollection');
+        $this->assertInstanceOf(Reference::class, $kernelPluginCollectionArgument);
+        $this->assertSame(KernelPluginCollection::class, (string) $kernelPluginCollectionArgument);
+
+        $this->assertArrayHasKey('$systemConfigService', $configurationCardConfigSaverDefinition->getArguments());
+        $systemConfigServiceArgument = $configurationCardConfigSaverDefinition->getArgument('$systemConfigService');
+        $this->assertInstanceOf(Reference::class, $systemConfigServiceArgument);
+        $this->assertSame(SystemConfigService::class, (string) $systemConfigServiceArgument);
+    }
+}


### PR DESCRIPTION
Because the persistence of default values (normally defined in the `config.xml` file) is done during the installation and not during activation of a plugin, the default values defined within this package, won't be saved.

This PR introduces a separate event subscriber that automatically persists the default configuration values after a plugin activation if the subscriber is enabled.