### PR TITLE
Prevention of multiple runs of the `ConfigurationCardConfigReaderPass`

### DIFF
--- a/tests/Unit/DependencyInjection/ConfigurationCardConfigReaderPassTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationCardConfigReaderPassTest.php
@@ -12,11 +12,109 @@ use ITB\ShopwareCodeBasedPluginConfiguration\DependencyInjection\ConfigurationCa
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\System\SystemConfig\Util\ConfigReader as BundleXmlConfigReader;
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
 final class ConfigurationCardConfigReaderPassTest extends TestCase
 {
+    public static function processAfterAlreadyRunProvider(): \Generator
+    {
+        $configurationCardConfigReaderPass = new ConfigurationCardConfigReaderPass();
+        $container = new ContainerBuilder();
+
+        $container->addDefinitions([
+            ConfigurationCardProviderProvider::class => new Definition(ConfigurationCardProviderProvider::class),
+            ConfigurationCardConfigReader::class => new Definition(ConfigurationCardConfigReader::class),
+        ]);
+        $container->addAliases([
+            ConfigurationCardProviderProviderInterface::class => new Alias(ConfigurationCardProviderProvider::class),
+            BundleXmlConfigReader::class => new Alias(ConfigurationCardConfigReader::class),
+        ]);
+
+        yield [$configurationCardConfigReaderPass, $container];
+    }
+
+    public static function processAfterInvalidRunProvider(): \Generator
+    {
+        $configurationCardConfigReaderPass = new ConfigurationCardConfigReaderPass();
+        $container = new ContainerBuilder();
+
+        $container->addDefinitions([
+            ConfigurationCardProviderProvider::class => new Definition(ConfigurationCardProviderProvider::class),
+        ]);
+
+        yield 'with ConfigurationCardProviderProvider definition' => [
+            $configurationCardConfigReaderPass,
+            $container,
+            \LogicException::class,
+            sprintf(
+                'The compiler contains a definition for %s but not the alias for %s.',
+                ConfigurationCardProviderProvider::class,
+                ConfigurationCardProviderProviderInterface::class
+            ),
+        ];
+
+        $container = new ContainerBuilder();
+
+        $container->addDefinitions([
+            ConfigurationCardProviderProvider::class => new Definition(ConfigurationCardProviderProvider::class),
+        ]);
+        $container->addAliases([
+            ConfigurationCardProviderProviderInterface::class => new Alias(ConfigurationCardProviderProvider::class),
+        ]);
+
+        yield 'with ConfigurationCardProviderProvider definition and ConfigurationCardProviderProviderInterface alias' => [
+            $configurationCardConfigReaderPass,
+            $container,
+            \LogicException::class,
+            sprintf('The compiler contains no definition for %s.', ConfigurationCardConfigReader::class),
+        ];
+
+        $container = new ContainerBuilder();
+
+        $container->addDefinitions([
+            ConfigurationCardProviderProvider::class => new Definition(ConfigurationCardProviderProvider::class),
+            ConfigurationCardConfigReader::class => new Definition(ConfigurationCardConfigReader::class),
+        ]);
+        $container->addAliases([
+            ConfigurationCardProviderProviderInterface::class => new Alias(ConfigurationCardProviderProvider::class),
+        ]);
+
+        yield 'with ConfigurationCardProviderProvider definition, ConfigurationCardConfigReader definition and ConfigurationCardProviderProviderInterface alias' => [
+            $configurationCardConfigReaderPass,
+            $container,
+            \LogicException::class,
+            sprintf(
+                'The compiler contains a definition for %s but not the alias for %s.',
+                ConfigurationCardConfigReader::class,
+                BundleXmlConfigReader::class
+            ),
+        ];
+
+        $container = new ContainerBuilder();
+
+        $container->addDefinitions([
+            ConfigurationCardProviderProvider::class => new Definition(ConfigurationCardProviderProvider::class),
+            ConfigurationCardConfigReader::class => new Definition(ConfigurationCardConfigReader::class),
+        ]);
+        $container->addAliases([
+            ConfigurationCardProviderProviderInterface::class => new Alias(ConfigurationCardProviderProvider::class),
+            BundleXmlConfigReader::class => new Alias('test'),
+        ]);
+
+        yield 'with ConfigurationCardProviderProvider definition, ConfigurationCardConfigReader definition, ConfigurationCardProviderProviderInterface alias and invalid BundleXmlConfigReader alias' => [
+            $configurationCardConfigReaderPass,
+            $container,
+            \LogicException::class,
+            sprintf(
+                'The compiler contains the alias %s but it does not point to %s.',
+                BundleXmlConfigReader::class,
+                ConfigurationCardConfigReader::class
+            ),
+        ];
+    }
+
     public static function processProvider(): \Generator
     {
         $configurationCardConfigReaderPass = new ConfigurationCardConfigReaderPass();
@@ -70,5 +168,32 @@ final class ConfigurationCardConfigReaderPassTest extends TestCase
         $this->assertTrue($container->hasAlias(BundleXmlConfigReader::class));
         $bundleXmlConfigReaderAlias = $container->getAlias(BundleXmlConfigReader::class);
         $this->assertSame(ConfigurationCardConfigReader::class, (string) $bundleXmlConfigReaderAlias);
+    }
+
+    #[DataProvider('processAfterAlreadyRunProvider')]
+    public function testProcessAfterAlreadyRun(
+        ConfigurationCardConfigReaderPass $configurationCardConfigReaderPass,
+        ContainerBuilder $container
+    ): void {
+        $configurationCardConfigReaderPass->process($container);
+
+        $configurationCardConfigReaderDefinition = $container->getDefinition(ConfigurationCardConfigReader::class);
+        $this->assertArrayNotHasKey('$bundleXmlConfigReader', $configurationCardConfigReaderDefinition->getArguments());
+    }
+
+    /**
+     * @param class-string<\Throwable> $expectedException
+     */
+    #[DataProvider('processAfterInvalidRunProvider')]
+    public function testProcessAfterInvalidRun(
+        ConfigurationCardConfigReaderPass $configurationCardConfigReaderPass,
+        ContainerBuilder $container,
+        string $expectedException,
+        string $expectedExceptionMessage
+    ): void {
+        $this->expectException($expectedException);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
+        $configurationCardConfigReaderPass->process($container);
     }
 }


### PR DESCRIPTION
If the `ConfigurationCardConfigReaderPass` runs multiple times, it will try to decorate the original `ConfigReader` multiple times. On the second run, there is no definiation for this service, only an alias. This leads to an execption.