### PR TITLE
Drop PHP 8.1 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     strategy:
       matrix:
-        php-versions: ['8.1', '8.2', '8.3']
+        php-versions: [ '8.2', '8.3' ]
       fail-fast: false
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": "^8.1",
+    "php": "^8.2",
     "shopware/core": "^6.5"
   },
   "require-dev": {


### PR DESCRIPTION
The PHP 8.1 support ended at 25.11.2023. All relevant Shopware versions (6.5.4.0 and above) support at least PHP 8.2.