### PR TITLE
Replacement of configuration card provider autotagging in compiler pass with attribute

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5,3 +5,21 @@ parameters:
 			identifier: return.type
 			count: 1
 			path: src/ConfigurationCardConfigReader.php
+
+		-
+			message: '#^Cannot access offset ''priority'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/DependencyInjection/ConfigurationCardConfigReaderPass.php
+
+		-
+			message: '#^Parameter \#2 \$priority of method ITB\\ShopwareCodeBasedPluginConfiguration\\DependencyInjection\\ConfigurationCardProviderReferenceCollection\:\:add\(\) expects int, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/DependencyInjection/ConfigurationCardConfigReaderPass.php
+
+		-
+			message: '#^Parameter \#2 \$configurator of method Symfony\\Component\\DependencyInjection\\ContainerBuilder\:\:registerAttributeForAutoconfiguration\(\) expects callable\(Symfony\\Component\\DependencyInjection\\ChildDefinition, ITB\\ShopwareCodeBasedPluginConfiguration\\Attribute\\AsConfigurationCardProvider, Reflector\)\: void, Closure\(Symfony\\Component\\DependencyInjection\\ChildDefinition, ITB\\ShopwareCodeBasedPluginConfiguration\\Attribute\\AsConfigurationCardProvider, ReflectionClass\)\: void given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/DependencyInjection/ConfigurationCardProviderTaggingPass.php

--- a/src/Attribute/AsConfigurationCardProvider.php
+++ b/src/Attribute/AsConfigurationCardProvider.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ShopwareCodeBasedPluginConfiguration\Attribute;
+
+/**
+ * Service tag to autoconfigure config card providers.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class AsConfigurationCardProvider
+{
+    public function __construct(
+        public int $priority = 0
+    ) {
+    }
+}

--- a/src/ConfigurationCardConfigReader/ConfigurationCardProviderProvider.php
+++ b/src/ConfigurationCardConfigReader/ConfigurationCardProviderProvider.php
@@ -19,7 +19,7 @@ final class ConfigurationCardProviderProvider implements ConfigurationCardProvid
     public function getBundleClasses(): array
     {
         $bundleClasses = [];
-        foreach ($this->getConfigurationCardProviders() as $configurationCardProvider) {
+        foreach ($this->configurationCardProviders as $configurationCardProvider) {
             $bundleClasses = array_merge($bundleClasses, $configurationCardProvider->getBundleClasses());
         }
 
@@ -31,13 +31,6 @@ final class ConfigurationCardProviderProvider implements ConfigurationCardProvid
      */
     public function getConfigurationCardProviders(): iterable
     {
-        $configurationCardProviders = [...$this->configurationCardProviders];
-
-        uasort(
-            $configurationCardProviders,
-            static fn (ConfigurationCardProvider $a, ConfigurationCardProvider $b): int => $b->getPriority() <=> $a->getPriority()
-        );
-
-        return array_values($configurationCardProviders);
+        return $this->configurationCardProviders;
     }
 }

--- a/src/ConfigurationCardProvider.php
+++ b/src/ConfigurationCardProvider.php
@@ -17,6 +17,4 @@ interface ConfigurationCardProvider
      * @return ConfigurationCard[]
      */
     public function getConfigurationCards(): array;
-
-    public function getPriority(): int;
 }

--- a/src/DependencyInjection/ConfigurationCardProviderReferenceCollection.php
+++ b/src/DependencyInjection/ConfigurationCardProviderReferenceCollection.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ShopwareCodeBasedPluginConfiguration\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Reference;
+
+final class ConfigurationCardProviderReferenceCollection
+{
+    /**
+     * @var array{id: string, priority: int}[]
+     */
+    private array $configurationCardProviderIdsWithPriorities = [];
+
+    public function add(string $id, int $priority): void
+    {
+        $this->configurationCardProviderIdsWithPriorities[] = [
+            'id' => $id,
+            'priority' => $priority,
+        ];
+    }
+
+    /**
+     * @return Reference[]
+     */
+    public function getReferences(): array
+    {
+        uasort(
+            $this->configurationCardProviderIdsWithPriorities,
+            static fn (array $a, array $b): int => $b['priority'] <=> $a['priority']
+        );
+
+        return array_values(array_map(
+            static fn (array $configurationCardProviderIdWithPriority): Reference => new Reference(
+                $configurationCardProviderIdWithPriority['id']
+            ),
+            $this->configurationCardProviderIdsWithPriorities
+        ));
+    }
+}

--- a/src/DependencyInjection/ConfigurationCardProviderTaggingPass.php
+++ b/src/DependencyInjection/ConfigurationCardProviderTaggingPass.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ShopwareCodeBasedPluginConfiguration\DependencyInjection;
+
+use ITB\ShopwareCodeBasedPluginConfiguration\Attribute\AsConfigurationCardProvider;
+use ITB\ShopwareCodeBasedPluginConfiguration\ConfigurationCardProvider;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class ConfigurationCardProviderTaggingPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $container->registerAttributeForAutoconfiguration(
+            AsConfigurationCardProvider::class,
+            static function (ChildDefinition $definition, AsConfigurationCardProvider $attribute, \ReflectionClass $reflector): void {
+                if (! $reflector->implementsInterface(ConfigurationCardProvider::class)) {
+                    throw new \RuntimeException(sprintf(
+                        'The class %s must implement %s to be used as a configuration card provider. The `AsConfigurationCardProvider` attribute cannot be used here.',
+                        $reflector->getName(),
+                        ConfigurationCardProvider::class
+                    ));
+                }
+
+                $definition->addTag(Tags::CONFIGURATION_CARD_PROVIDER_TAG, [
+                    'priority' => $attribute->priority,
+                ]);
+            }
+        );
+    }
+}

--- a/src/DependencyInjection/Tags.php
+++ b/src/DependencyInjection/Tags.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ShopwareCodeBasedPluginConfiguration\DependencyInjection;
+
+final class Tags
+{
+    public const CONFIGURATION_CARD_PROVIDER_TAG = 'itb.shopware_code_based_plugin_configuration.configuration_card_provider';
+}

--- a/tests/Function/ConfigurationCardProviderProviderTest.php
+++ b/tests/Function/ConfigurationCardProviderProviderTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ShopwareCodeBasedPluginConfiguration\Test\Function;
+
+use ITB\ShopwareCodeBasedPluginConfiguration\ConfigurationCardConfigReader\ConfigurationCardProviderProvider;
+use ITB\ShopwareCodeBasedPluginConfiguration\ConfigurationCardConfigReader\ConfigurationCardProviderProviderInterface;
+use ITB\ShopwareCodeBasedPluginConfiguration\ConfigurationCardProvider;
+use ITB\ShopwareCodeBasedPluginConfiguration\Test\Function\Mock\ConfigurationCardProvider1;
+use ITB\ShopwareCodeBasedPluginConfiguration\Test\Function\Mock\ConfigurationCardProvider2;
+use ITB\ShopwareCodeBasedPluginConfiguration\Test\Function\Mock\ConfigurationCardProvider3;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigurationCardProviderProviderTest extends TestCase
+{
+    public function test(): void
+    {
+        $kernel = new ITBShopwareCodeBasePluginConfigrationTestKernel([
+            ConfigurationCardProvider1::class,
+            ConfigurationCardProvider2::class,
+        ]);
+        $kernel->boot();
+
+        $container = $kernel->getContainer();
+
+        $configurationCardProviderProvider = $container->get(ConfigurationCardProviderProviderInterface::class);
+        $this->assertInstanceOf(ConfigurationCardProviderProvider::class, $configurationCardProviderProvider);
+
+        $configurationCardProviders = iterator_to_array($configurationCardProviderProvider->getConfigurationCardProviders());
+        $this->assertCount(2, $configurationCardProviders);
+        $this->assertContainsOnlyInstancesOf(ConfigurationCardProvider::class, $configurationCardProviders);
+
+        $this->assertInstanceOf(ConfigurationCardProvider1::class, $configurationCardProviders[0]);
+        $this->assertInstanceOf(ConfigurationCardProvider2::class, $configurationCardProviders[1]);
+    }
+
+    public function testWithConfigurationCardProviderThatDoesntImplementInterface(): void
+    {
+        $kernel = new ITBShopwareCodeBasePluginConfigrationTestKernel([ConfigurationCardProvider3::class]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(sprintf(
+            'The class %s must implement %s to be used as a configuration card provider. The `AsConfigurationCardProvider` attribute cannot be used here.',
+            ConfigurationCardProvider3::class,
+            ConfigurationCardProvider::class
+        ));
+        $kernel->boot();
+    }
+}

--- a/tests/Function/ITBShopwareCodeBasePluginConfigrationTestKernel.php
+++ b/tests/Function/ITBShopwareCodeBasePluginConfigrationTestKernel.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ShopwareCodeBasedPluginConfiguration\Test\Function;
+
+use ITB\ShopwareCodeBasedPluginConfiguration\DependencyInjection\ConfigurationCardConfigReaderPass;
+use ITB\ShopwareCodeBasedPluginConfiguration\DependencyInjection\ConfigurationCardConfigSaverPass;
+use ITB\ShopwareCodeBasedPluginConfiguration\DependencyInjection\ConfigurationCardProviderTaggingPass;
+use ITB\ShopwareCodeBasedPluginConfiguration\Test\Function\TestCompiler\PublishServicesForTestsCompilerPass;
+use ITB\ShopwareCodeBasedPluginConfiguration\Test\Function\TestCompiler\ShopwareServicesCompilerPass;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\HttpKernel\Kernel;
+
+final class ITBShopwareCodeBasePluginConfigrationTestKernel extends Kernel
+{
+    /**
+     * @param class-string[] $configurationCardProviderClassesToRegister
+     */
+    public function __construct(
+        private readonly array $configurationCardProviderClassesToRegister
+    ) {
+        parent::__construct('test', true);
+    }
+
+    public function getCacheDir(): string
+    {
+        return __DIR__ . '/../../var/cache/' . spl_object_hash($this);
+    }
+
+    public function registerBundles(): iterable
+    {
+        return [];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader): void
+    {
+        $loader->load(function (ContainerBuilder $container): void {
+            foreach ($this->configurationCardProviderClassesToRegister as $configurationCardProviderClassToRegister) {
+                $configurationCardProvider = new Definition($configurationCardProviderClassToRegister);
+                $configurationCardProvider->setAutowired(true);
+                $configurationCardProvider->setAutoconfigured(true);
+                $container->setDefinition($configurationCardProviderClassToRegister, $configurationCardProvider);
+            }
+
+            $container->addCompilerPass(new ShopwareServicesCompilerPass());
+
+            $container->addCompilerPass(new ConfigurationCardProviderTaggingPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1000);
+            $container->addCompilerPass(new ConfigurationCardConfigReaderPass());
+            $container->addCompilerPass(new ConfigurationCardConfigSaverPass());
+
+            $container->addCompilerPass(new PublishServicesForTestsCompilerPass());
+        });
+    }
+}

--- a/tests/Function/Mock/ConfigurationCardProvider1.php
+++ b/tests/Function/Mock/ConfigurationCardProvider1.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ShopwareCodeBasedPluginConfiguration\Test\Function\Mock;
+
+use ITB\ShopwareCodeBasedPluginConfiguration\Attribute\AsConfigurationCardProvider;
+use ITB\ShopwareCodeBasedPluginConfiguration\ConfigurationCardProvider;
+
+#[AsConfigurationCardProvider(priority: 100)]
+final class ConfigurationCardProvider1 implements ConfigurationCardProvider
+{
+    public function getBundleClasses(): array
+    {
+        return [];
+    }
+
+    public function getConfigurationCards(): array
+    {
+        return [];
+    }
+
+    public function getPriority(): int
+    {
+        return 0;
+    }
+}

--- a/tests/Function/Mock/ConfigurationCardProvider1.php
+++ b/tests/Function/Mock/ConfigurationCardProvider1.php
@@ -19,9 +19,4 @@ final class ConfigurationCardProvider1 implements ConfigurationCardProvider
     {
         return [];
     }
-
-    public function getPriority(): int
-    {
-        return 0;
-    }
 }

--- a/tests/Function/Mock/ConfigurationCardProvider2.php
+++ b/tests/Function/Mock/ConfigurationCardProvider2.php
@@ -19,9 +19,4 @@ final class ConfigurationCardProvider2 implements ConfigurationCardProvider
     {
         return [];
     }
-
-    public function getPriority(): int
-    {
-        return 0;
-    }
 }

--- a/tests/Function/Mock/ConfigurationCardProvider2.php
+++ b/tests/Function/Mock/ConfigurationCardProvider2.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ShopwareCodeBasedPluginConfiguration\Test\Function\Mock;
+
+use ITB\ShopwareCodeBasedPluginConfiguration\Attribute\AsConfigurationCardProvider;
+use ITB\ShopwareCodeBasedPluginConfiguration\ConfigurationCardProvider;
+
+#[AsConfigurationCardProvider]
+final class ConfigurationCardProvider2 implements ConfigurationCardProvider
+{
+    public function getBundleClasses(): array
+    {
+        return [];
+    }
+
+    public function getConfigurationCards(): array
+    {
+        return [];
+    }
+
+    public function getPriority(): int
+    {
+        return 0;
+    }
+}

--- a/tests/Function/Mock/ConfigurationCardProvider3.php
+++ b/tests/Function/Mock/ConfigurationCardProvider3.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ShopwareCodeBasedPluginConfiguration\Test\Function\Mock;
+
+use ITB\ShopwareCodeBasedPluginConfiguration\Attribute\AsConfigurationCardProvider;
+
+#[AsConfigurationCardProvider]
+final class ConfigurationCardProvider3
+{
+}

--- a/tests/Function/TestCompiler/PublishServicesForTestsCompilerPass.php
+++ b/tests/Function/TestCompiler/PublishServicesForTestsCompilerPass.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ShopwareCodeBasedPluginConfiguration\Test\Function\TestCompiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class PublishServicesForTestsCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (! $this->isPHPUnit()) {
+            return;
+        }
+
+        foreach ($container->getDefinitions() as $definition) {
+            $definition->setPublic(true);
+        }
+
+        foreach ($container->getAliases() as $definition) {
+            $definition->setPublic(true);
+        }
+    }
+
+    private function isPHPUnit(): bool
+    {
+        // the constants are defined by PHPUnit
+        return defined('PHPUNIT_COMPOSER_INSTALL') || defined('__PHPUNIT_PHAR__');
+    }
+}

--- a/tests/Function/TestCompiler/RegisterConfigurationCardProvidersCompilerPass.php
+++ b/tests/Function/TestCompiler/RegisterConfigurationCardProvidersCompilerPass.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ShopwareCodeBasedPluginConfiguration\Test\Function\TestCompiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class RegisterConfigurationCardProvidersCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+    }
+}

--- a/tests/Function/TestCompiler/ShopwareServicesCompilerPass.php
+++ b/tests/Function/TestCompiler/ShopwareServicesCompilerPass.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ShopwareCodeBasedPluginConfiguration\Test\Function\TestCompiler;
+
+use Shopware\Core\Framework\Plugin\KernelPluginCollection;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Shopware\Core\System\SystemConfig\Util\ConfigReader;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+final class ShopwareServicesCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $configReader = new Definition(ConfigReader::class);
+        $container->setDefinition(ConfigReader::class, $configReader);
+
+        $kernelPluginCollection = new Definition(KernelPluginCollection::class);
+        $container->setDefinition(KernelPluginCollection::class, $kernelPluginCollection);
+
+        $systemConfigService = new Definition(SystemConfigService::class);
+        $container->setDefinition(SystemConfigService::class, $systemConfigService);
+    }
+}

--- a/tests/Unit/ConfigurationCardConfigReader/ConfigurationCardProviderProviderTest.php
+++ b/tests/Unit/ConfigurationCardConfigReader/ConfigurationCardProviderProviderTest.php
@@ -14,8 +14,6 @@ final class ConfigurationCardProviderProviderTest extends TestCase
     public static function constructionProvider(): \Generator
     {
         $configurationCardProvider = self::createStub(ConfigurationCardProvider::class);
-        $configurationCardProvider->method('getPriority')
-            ->willReturn(0);
 
         yield [[$configurationCardProvider]];
     }
@@ -80,11 +78,7 @@ final class ConfigurationCardProviderProviderTest extends TestCase
         yield 'without configuration card providers' => [$configurationCardProviderProvider, []];
 
         $configurationCardProvider1 = self::createStub(ConfigurationCardProvider::class);
-        $configurationCardProvider1->method('getPriority')
-            ->willReturn(0);
         $configurationCardProvider2 = self::createStub(ConfigurationCardProvider::class);
-        $configurationCardProvider2->method('getPriority')
-            ->willReturn(1);
 
         $configurationCardProviderProvider = new ConfigurationCardProviderProvider([
             $configurationCardProvider1,

--- a/tests/Unit/ConfigurationCardConfigReader/ConfigurationCardProviderProviderTest.php
+++ b/tests/Unit/ConfigurationCardConfigReader/ConfigurationCardProviderProviderTest.php
@@ -84,9 +84,9 @@ final class ConfigurationCardProviderProviderTest extends TestCase
             $configurationCardProvider1,
             $configurationCardProvider2,
         ]);
-        yield 'with two configuration card providers with different priorities' => [
+        yield 'with two configuration card providers' => [
             $configurationCardProviderProvider,
-            [$configurationCardProvider2, $configurationCardProvider1],
+            [$configurationCardProvider1, $configurationCardProvider2],
         ];
     }
 


### PR DESCRIPTION
The `ConfigurationCardConfigReaderPass` implemented an autotagging mechanism that iterated through all registered services in the DI container and tagged them if they implemented the`ConfigurationCardProvider` interface.

This lead to the loading of classes through reflection that were not used by the project this bundle is used in. The loading could trigger a deprecation warning if the class file contained one.

In environment like testing, these deprecation warnings could lead to failed tests or test pipelines without any developer error.